### PR TITLE
Use empty list if legacy links not found

### DIFF
--- a/lib/compiler.ex
+++ b/lib/compiler.ex
@@ -20,7 +20,7 @@ defmodule TzExtra.Compiler do
 
     get_all_time_zone_links_for_canonical_fun =
       fn canonical ->
-        time_zones[canonical] ++ legacy_links[canonical]
+        time_zones[canonical] ++ (legacy_links[canonical] || [])
       end
 
     countries_time_zones =


### PR DESCRIPTION
when `time_zones[canonical]` is `[]` and `legacy_links[canonical]` is `nil`, then the whole expression is `nil` as well, as
`[] ++ nil` returns `nil`